### PR TITLE
Add resource analysis and binary downloads

### DIFF
--- a/app/components/HtmlAnalysis.tsx
+++ b/app/components/HtmlAnalysis.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { ResponseViewer, ResponseData } from "./ResponseViewer";
+
+interface Resource {
+  url: string;
+  content?: ResponseData;
+}
+
+export function HtmlAnalysis({ html, baseUrl }: { html: string; baseUrl: string }) {
+  const [resources, setResources] = useState<Resource[]>([]);
+
+  useEffect(() => {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const srcs = [
+      ...Array.from(doc.querySelectorAll("script[src]"), (e) => (e as HTMLScriptElement).src),
+      ...Array.from(doc.querySelectorAll("link[rel=stylesheet]"), (e) => (e as HTMLLinkElement).href),
+    ];
+    const resolved = srcs.map((s) => new URL(s, baseUrl).href);
+    setResources(resolved.map((url) => ({ url })));
+  }, [html, baseUrl]);
+
+  const view = async (url: string) => {
+    const res = await fetch("/api/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ method: "GET", url }),
+    });
+    const data = (await res.json()) as ResponseData;
+    setResources((r) => r.map((it) => (it.url === url ? { ...it, content: data } : it)));
+  };
+
+  if (!resources.length) return null;
+
+  return (
+    <div className="space-y-2">
+      <h3 className="font-medium">Resources</h3>
+      <ul className="space-y-2">
+        {resources.map((r) => (
+          <li key={r.url} className="space-y-1">
+            <div className="flex items-center justify-between">
+              <span className="truncate text-sm">{r.url}</span>
+              <button
+                className="text-blue-600 underline"
+                onClick={() => view(r.url)}
+              >
+                View
+              </button>
+            </div>
+            {r.content && (
+              <div className="border rounded-md p-2">
+                <ResponseViewer response={r.content} />
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/components/HtmlViewer.tsx
+++ b/app/components/HtmlViewer.tsx
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from "react";
+
+export function HtmlViewer({ html }: { html: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const shadow = ref.current.shadowRoot || ref.current.attachShadow({ mode: "open" });
+    shadow.innerHTML = html || "";
+  }, [html]);
+
+  return <div ref={ref} className="w-full border rounded-md min-h-[200px]" />;
+}

--- a/app/components/ResponseViewer.tsx
+++ b/app/components/ResponseViewer.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { HtmlViewer } from "./HtmlViewer";
+
+/* eslint-disable jsx-a11y/media-has-caption */
+
+export interface ResponseData {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+  contentType: string | null;
+  error?: string;
+  isBase64?: boolean;
+}
+
+export function ResponseViewer({ response }: { response: ResponseData }) {
+  const { contentType, body, isBase64 } = response;
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isBase64) {
+      const binary = Uint8Array.from(atob(body), (c) => c.charCodeAt(0));
+      const blob = new Blob([binary], { type: contentType || "application/octet-stream" });
+      const objectUrl = URL.createObjectURL(blob);
+      setUrl(objectUrl);
+      return () => URL.revokeObjectURL(objectUrl);
+    }
+    setUrl(null);
+    return;
+  }, [body, contentType, isBase64]);
+
+  if (contentType?.includes("text/html")) {
+    return <HtmlViewer html={body} />;
+  }
+
+  if (contentType?.includes("application/json")) {
+    try {
+      const json = JSON.parse(body);
+      return (
+        <pre className="whitespace-pre-wrap rounded-md border p-2 min-h-[200px]">
+          {JSON.stringify(json, null, 2)}
+        </pre>
+      );
+    } catch {
+      return <pre className="whitespace-pre-wrap">{body}</pre>;
+    }
+  }
+
+  if (contentType?.startsWith("text/")) {
+    return (
+      <pre className="whitespace-pre-wrap rounded-md border p-2 min-h-[200px]">
+        {body}
+      </pre>
+    );
+  }
+
+  if (contentType?.startsWith("image/") && url) {
+    return (
+      <div className="space-y-2">
+        <img src={url} alt="response" className="max-w-full" />
+        <a
+          href={url}
+          download
+          className="text-blue-600 underline"
+        >
+          Download
+        </a>
+      </div>
+    );
+  }
+
+  if (contentType?.startsWith("video/") && url) {
+    return (
+      <div className="space-y-2">
+        <video src={url} controls className="max-w-full" />
+        <a
+          href={url}
+          download
+          className="text-blue-600 underline"
+        >
+          Download
+        </a>
+      </div>
+    );
+  }
+
+  if (url) {
+    return (
+      <a href={url} download className="text-blue-600 underline">
+        Download file
+      </a>
+    );
+  }
+
+  return <pre className="whitespace-pre-wrap">{body}</pre>;
+}

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "~/lib/utils";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        "inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus:outline-none",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Button.displayName = "Button";

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "~/lib/utils";
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";

--- a/app/components/ui/textarea.tsx
+++ b/app/components/ui/textarea.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "~/lib/utils";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = "Textarea";

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,17 +1,137 @@
-import type { MetaFunction } from "@remix-run/node";
-import { Layout } from "lucide-react";
+import { useState } from "react";
+import { MetaFunction } from "@remix-run/node";
+import { Input } from "~/components/ui/input";
+import { Textarea } from "~/components/ui/textarea";
+import { Button } from "~/components/ui/button";
+import { ResponseViewer, type ResponseData } from "~/components/ResponseViewer";
+import { HtmlAnalysis } from "~/components/HtmlAnalysis";
 
-export const meta: MetaFunction = () => {
-  return [
-    { title: "New Remix App" },
-    { name: "description", content: "Welcome to Remix!" },
-  ];
-};
+export const meta: MetaFunction = () => [{ title: "HTTP Client" }];
+
+
+function parseHeaders(text: string) {
+  const lines = text.split(/\r?\n/);
+  const headers: Record<string, string> = {};
+  for (const line of lines) {
+    const [key, ...rest] = line.split(":");
+    if (key && rest.length) headers[key.trim()] = rest.join(":").trim();
+  }
+  return headers;
+}
+
+function parseQuery(text: string) {
+  const params = new URLSearchParams();
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const [key, ...rest] = line.split(":");
+    if (key && rest.length) params.append(key.trim(), rest.join(":").trim());
+  }
+  return params.toString();
+}
 
 export default function Index() {
+  const [method, setMethod] = useState("GET");
+  const [url, setUrl] = useState("");
+  const [headers, setHeaders] = useState("");
+  const [query, setQuery] = useState("");
+  const [body, setBody] = useState("");
+  const [response, setResponse] = useState<ResponseData | null>(null);
+
+  const send = async () => {
+    setResponse(null);
+    let target = url;
+    const q = parseQuery(query);
+    if (q) {
+      target = target.includes("?") ? `${target}&${q}` : `${target}?${q}`;
+    }
+    const res = await fetch("/api/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method,
+        url: target,
+        headers: parseHeaders(headers),
+        body,
+      }),
+    });
+    const data = (await res.json()) as ResponseData;
+    setResponse(data);
+  };
+
   return (
-    <Layout>
-      <h1>Index</h1>
-    </Layout>
+    <div className="container mx-auto p-4 space-y-4">
+      <div className="flex items-end space-x-2">
+        <select
+          className="h-10 rounded-md border border-input bg-background px-2"
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+        >
+          {[
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE",
+            "HEAD",
+          ].map((m) => (
+            <option key={m}>{m}</option>
+          ))}
+        </select>
+        <Input
+          placeholder="https://example.com"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <Button onClick={send}>Send</Button>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label htmlFor="headers" className="font-medium">Headers</label>
+          <Textarea
+            id="headers"
+            className="min-h-[120px]"
+            value={headers}
+            onChange={(e) => setHeaders(e.target.value)}
+          />
+          <div className="space-y-1">
+            <label htmlFor="query" className="font-medium">Query</label>
+            <Textarea
+              id="query"
+              className="min-h-[80px]"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+          {method !== "GET" && method !== "HEAD" && (
+            <div className="space-y-1">
+              <label htmlFor="body" className="font-medium">Body</label>
+              <Textarea
+                id="body"
+                className="min-h-[120px]"
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+              />
+            </div>
+          )}
+        </div>
+        {response && (
+          <div className="space-y-2">
+            <div className="text-sm font-medium">
+              Status: {response.status} {response.statusText}
+            </div>
+            <ResponseViewer response={response} />
+            <details className="border rounded-md p-2">
+              <summary className="cursor-pointer">Headers</summary>
+              <pre className="whitespace-pre-wrap">
+                {JSON.stringify(response.headers, null, 2)}
+              </pre>
+            </details>
+            {response.contentType?.includes("text/html") && (
+              <HtmlAnalysis html={response.body} baseUrl={url} />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/app/routes/api.request.ts
+++ b/app/routes/api.request.ts
@@ -1,0 +1,43 @@
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+
+export async function action({ request }: ActionFunctionArgs) {
+  try {
+    const { method = "GET", url, headers = {}, body } = await request.json();
+    if (!url) {
+      return json({ error: "Missing url" }, { status: 400 });
+    }
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: method === "GET" || method === "HEAD" ? undefined : body,
+    });
+
+    const contentType = response.headers.get("content-type");
+    let bodyText: string;
+    let isBase64 = false;
+
+    if (contentType && /^text|application\/json/.test(contentType)) {
+      bodyText = await response.text();
+    } else {
+      const buffer = Buffer.from(await response.arrayBuffer());
+      bodyText = buffer.toString("base64");
+      isBase64 = true;
+    }
+
+    return json(
+      {
+        status: response.status,
+        statusText: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        body: bodyText,
+        contentType,
+        isBase64,
+      },
+      { status: 200 }
+    );
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return json({ error: message }, { status: 500 });
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,67 +4,67 @@ export default {
     darkMode: ["class"],
     content: ["./app/**/{**,.client,.server}/**/*.{js,jsx,ts,tsx}"],
   theme: {
-  	extend: {
-  		fontFamily: {
-  			sans: [
-  				'Inter',
-  				'ui-sans-serif',
-  				'system-ui',
-  				'sans-serif',
-  				'Apple Color Emoji',
-  				'Segoe UI Emoji',
-  				'Segoe UI Symbol',
-  				'Noto Color Emoji'
-  			]
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		}
-  	}
+    extend: {
+      fontFamily: {
+        sans: [
+          'Inter',
+          'ui-sans-serif',
+          'system-ui',
+          'sans-serif',
+          'Apple Color Emoji',
+          'Segoe UI Emoji',
+          'Segoe UI Symbol',
+          'Noto Color Emoji'
+        ]
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      },
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))'
+        },
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))'
+        },
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        chart: {
+          '1': 'hsl(var(--chart-1))',
+          '2': 'hsl(var(--chart-2))',
+          '3': 'hsl(var(--chart-3))',
+          '4': 'hsl(var(--chart-4))',
+          '5': 'hsl(var(--chart-5))'
+        }
+      }
+    }
   },
   plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- support query parameters and binary responses
- render responses with `<ResponseViewer>` and analyze HTML sources
- enable resource listing and viewing in `<HtmlAnalysis>`

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68415d734c80832aa792422567f7eff9