### PR TITLE
Handle API errors on index route

### DIFF
--- a/app/components/ui/alert.tsx
+++ b/app/components/ui/alert.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "~/lib/utils";
+
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn(
+        "w-full rounded-md border border-destructive/50 bg-destructive/20 p-4 text-sm text-destructive",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Alert.displayName = "Alert";

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import { Button } from "~/components/ui/button";
 import { ResponseViewer, type ResponseData } from "~/components/ResponseViewer";
 import { HtmlAnalysis } from "~/components/HtmlAnalysis";
 import { ScriptAnalysis } from "~/components/ScriptAnalysis";
+import { Alert } from "~/components/ui/alert";
 
 export const meta: MetaFunction = () => [{ title: "HTTP Client" }];
 
@@ -39,6 +40,7 @@ export default function Index() {
   const [query, setQuery] = useState("");
   const [body, setBody] = useState("");
   const [response, setResponse] = useState<ResponseData | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [analysis, setAnalysis] = useState<
     {
       html: string;
@@ -52,6 +54,7 @@ export default function Index() {
   }, []);
 
   const send = async () => {
+    setError(null);
     setResponse(null);
     setAnalysis(null);
     let target = url;
@@ -73,10 +76,15 @@ export default function Index() {
       }),
     });
     const data = (await res.json()) as ResponseData;
+    if (data.error) {
+      setError(data.error);
+      return;
+    }
     setResponse(data);
   };
 
   const analyze = async () => {
+    setError(null);
     setAnalysis(null);
     const res = await fetch("/api/analyze", {
       method: "POST",
@@ -159,6 +167,9 @@ export default function Index() {
             </div>
           )}
         </div>
+        {error && (
+          <Alert className="col-span-2">{error}</Alert>
+        )}
         {response && (
           <div className="space-y-2">
             <div className="text-sm font-medium">


### PR DESCRIPTION
## Summary
- add a shadcn-style `Alert` component
- handle `error` responses in `_index` route
- show an alert if the request fails
- reset errors on new requests

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684169c95f18832abb312eadbe7317d4